### PR TITLE
Type 'ShellPlatform' has no call signatures - docfix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ scripts are packaged as part of your delivlib CDK app.
 
 ```ts
 delivlib.addTest('MyTest', {
-  platform: delivlib.ShellPlatform.LinuxUbuntu(), // or `ShellPlatform.Windows()`
+  platform: delivlib.ShellPlatform.LinuxUbuntu, // or `ShellPlatform.Windows`
   scriptDirectory: 'path/to/local/directory/with/tests',
   entrypoint: 'run.sh',
 });


### PR DESCRIPTION
The README uses `delivlib.ShellPlatform.LinuxUbuntu()` as the example platform when writing a pipeline test.

This fails at `cdk synth` in TypeScript:

```sh
❯ cdk synth                                                                                                                                                       
⨯ Unable to compile TypeScript:
lib/pipeline-stack.ts:56:37 - error TS2349: This expression is not callable.
  Type 'ShellPlatform' has no call signatures.

56       platform: deliv.ShellPlatform.LinuxUbuntu(),
                                       ~~~~~~~~~~~
```
Removing the function call `()` resolves this error, and the template continues to synthesize.

The `LinuxUbuntu` property defaults to the property instead of the call in the definition:

https://github.com/cdklabs/aws-delivlib/blob/59a6915f3626f15dd6df6fa165af400f9b01cbd5/lib/shellable.ts#L24-L29

I think this may have mistakenly in reference to the getter in the abstract class? https://github.com/cdklabs/aws-delivlib/blob/59a6915f3626f15dd6df6fa165af400f9b01cbd5/lib/shellable.ts#L371-L374

The CodeBuild construct also references the `LinuxUbuntu` property at this line of code: https://github.com/cdklabs/aws-delivlib/blob/59a6915f3626f15dd6df6fa165af400f9b01cbd5/lib/shellable.ts#L250

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
